### PR TITLE
Update DF and and iso build to .sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL name="CentOS RepoSync"
 COPY syncfile.sh /tmp/syncfile.sh
 RUN echo "Performing RepoSync. Hopefully you created a volume.." && \
     yum install -y epel-release && \
-    yum update -y && \
+    yum update -y && yum install genisoimage -y && \
     chmod 0755 /tmp/syncfile.sh && \
     mkdir -p /repos && cd /repos
 

--- a/syncfile.sh
+++ b/syncfile.sh
@@ -3,3 +3,17 @@ reposync -g -l -d -m --repoid=centosplus --download-metadata --newest-only
 reposync -g -l -d -m --repoid=extras --download-metadata --newest-only
 reposync -g -l -d -m --repoid=updates --download-metadata --newest-only
 reposync -g -l -d -m --repoid=epel --download-metadata --newest-only
+
+#Create ISO of your updated repos
+FILE=./repos.iso
+if [ -e "$FILE" ]; then
+    echo "$FILE exists. Removing $FILE"
+    rm -rf $FILE
+    echo "$FILE Removed. Recreating"
+    read -t 3
+    genisoimage -o repos.iso *
+else 
+    echo "Creating $FILE"
+    genisoimage -o repos.iso *
+fi
+


### PR DESCRIPTION
Updates docker image with genisoimage package and adds the creation of an ISO for the repos for an easier offline transfer. Script will check for ISO with specific name in the /repos directory(within the container). If present will delete the iso and recreate, if not there just creates the ISO.